### PR TITLE
Add options for specifing year and target migration. Also handle .designer files correctly for mssql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StewardEF 🛠️
 
-StewardEF is a tool designed to make managing Entity Framework (EF) migrations easier for projects with a lengthy history. 
+StewardEF is a tool designed to make managing Entity Framework (EF) migrations easier for projects with a lengthy history.
 Specifically, it is able to squash your migrations back to a single file and drastically speed up your build times.
 
 EF Core does not yet provide a built-in solution for squashing migrations yet ([relevant issue here](https://github.com/dotnet/efcore/issues/2174)), but in the meantime, StewardEF can help fill the gap.
@@ -24,16 +24,18 @@ Squashes EF migrations into the first migration in the specified directory.
 #### **Usage:**
 
 ```bash
-steward squash -d path/to/migrations [-y year]
+steward squash -d path/to/migrations [-y year] [-t target]
 ```
+
 ##### Options
 
 - `-d (or [MigrationsDirectory])`: Path to the directory containing your EF migrations. If omitted, you'll be prompted to enter it interactively.
 - `-y (or [Year])`: Optional. Specify the year up to which migrations should be squashed. If omitted, all migrations will be squashed.
+- `-t (or [TargetMigration])`: Optional. Specify the target migration up to which migrations should be squashed. If omitted, all migrations will be squashed.
 
 #### **How It Works**
 
-> ⚠️ The squash command will modify your migrations files, so **please** be sure to start with a clean commit before suqashing so you can easily undo your changes if needed
+> ⚠️ The squash command will modify your migrations files, so **please** be sure to start with a clean commit before squashing so you can easily undo your changes if needed
 
 The squash command combines all existing migrations into a single, consolidated migration file. Here's how it works:
 

--- a/StewardEF/Program.cs
+++ b/StewardEF/Program.cs
@@ -20,7 +20,7 @@ app.Configure(config =>
         .WithDescription("Squashes EF migrations into the first migration.")
         .WithExample(new[] { "steward squash", "-d", "path/to/migrations" })
         .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-y", "2023" })
-        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-t", "Target migration");
+        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-t", "Target migration" });
 });
 
 try

--- a/StewardEF/Program.cs
+++ b/StewardEF/Program.cs
@@ -1,9 +1,9 @@
-﻿using System.Runtime.InteropServices;
-using System.Text;
-using Spectre.Console;
+﻿using Spectre.Console;
 using Spectre.Console.Cli;
 using StewardEF;
 using StewardEF.Commands;
+using System.Runtime.InteropServices;
+using System.Text;
 
 var app = new CommandApp();
 
@@ -18,7 +18,9 @@ app.Configure(config =>
 
     config.AddCommand<SquashMigrationsCommand>("squash")
         .WithDescription("Squashes EF migrations into the first migration.")
-        .WithExample(["steward squash", "-d", "path/to/migrations"]);
+        .WithExample(new[] { "steward squash", "-d", "path/to/migrations" })
+        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-y", "2023" })
+        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-t", "Target migration");
 });
 
 try


### PR DESCRIPTION
Hi!

Thanks for creating this tool!
I just used it to squash 890 migrations in our project reduing ram used when building from 14gb to 3gb 🥳 

For our use case i needed to be able to specify which migration to end at because of long lived branches i didnt want to squash all files.

I also noticed that atleast when using an mssql database the designer file need to be the snapshot of database when squashed migration is run. So i added functionallity to copy the latest designer file and rename it to match name of first migration