### PR TITLE
Remove -d from example and readme

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C#: Squash Migrations Debug",
+            "type": "dotnet",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}/StewardEF/StewardEF.csproj",
+            "args": [
+                "squash",
+                "/Users/darrenkattan/Documents/GitHub/immybot/backend/Immybot.Backend.Persistence/Migrations",
+                "-y 2024",
+            ],
+        }
+
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Squashes EF migrations into the first migration in the specified directory.
 #### **Usage:**
 
 ```bash
-steward squash -d path/to/migrations [-y year] [-t target]
+steward squash path/to/migrations [-y year] [-t target]
 ```
 
 ##### Options
 
-- `-d (or [MigrationsDirectory])`: Path to the directory containing your EF migrations. If omitted, you'll be prompted to enter it interactively.
-- `-y (or [Year])`: Optional. Specify the year up to which migrations should be squashed. If omitted, all migrations will be squashed.
-- `-t (or [TargetMigration])`: Optional. Specify the target migration up to which migrations should be squashed. If omitted, all migrations will be squashed.
+- `[MigrationsDirectory]`: Path to the directory containing your EF migrations. If omitted, you'll be prompted to enter it interactively.
+- `-y|--year`: Optional. Specify the year up to which migrations should be squashed. If omitted, all migrations will be squashed.
+- `-t|--target`: Optional. Specify the target migration up to which migrations should be squashed. If omitted, all migrations will be squashed.
 
 #### **How It Works**
 

--- a/StewardEF/Program.cs
+++ b/StewardEF/Program.cs
@@ -18,9 +18,9 @@ app.Configure(config =>
 
     config.AddCommand<SquashMigrationsCommand>("squash")
         .WithDescription("Squashes EF migrations into the first migration.")
-        .WithExample(new[] { "steward squash", "-d", "path/to/migrations" })
-        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-y", "2023" })
-        .WithExample(new[] { "steward squash", "-d", "path/to/migrations", "-t", "Target migration" });
+        .WithExample(new[] { "steward squash", "path/to/migrations" })
+        .WithExample(new[] { "steward squash", "path/to/migrations", "-y", "2023" })
+        .WithExample(new[] { "steward squash", "path/to/migrations", "-t", "Target migration" });
 });
 
 try


### PR DESCRIPTION
# Fix migrations directory parameter documentation

## Description
Fixes incorrect documentation that showed the migrations directory parameter as a `-d` option when it is actually implemented as a positional argument.

### Changes
- Updated examples in `Program.cs` to remove incorrect `-d` flag usage
- Updated README.md to show correct command syntax and parameter descriptions
- Improved option documentation to use consistent syntax format (`-y|--year` and `-t|--target`)

### Before
```bash
steward squash -d path/to/migrations [-y year] [-t target]
```

### After
```bash
steward squash path/to/migrations [-y year] [-t target]
```

This change is documentation-only and does not affect any functionality. The tool was already correctly handling the migrations directory as a positional argument.