### PR TITLE
Enclose migrations in their own scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,3 @@ The squash command combines all existing migrations into a single, consolidated 
 Depending on how your migrations were structured, you might need to make some manual adjustments after running squash. Some things to watch for:
 
 - Private Fields: If any private readonly fields or other member data are in your migrations, ensure they're properly defined in the combined migration file.
-- Variable Conflicts: Sometimes migrations contain variables with the same name across different files. Double-check the final file for duplicate variables and resolve them accordingly.

--- a/StewardEF/Commands/SquashMigrations.cs
+++ b/StewardEF/Commands/SquashMigrations.cs
@@ -132,7 +132,7 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
 
     private class AggregatedMethodResult
     {
-        public string AggregatedContent { get; set; }
+        public string AggregatedContent { get; set; } = null!;
         public HashSet<string> UsingStatements { get; set; } = [];
     }
 
@@ -161,8 +161,10 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
             var methodContent = ExtractMethodContent(migrationLines, methodName);
             if (!string.IsNullOrEmpty(methodContent))
             {
+                aggregatedContent.AppendLine("{");
                 aggregatedContent.AppendLine($"// {fileName}");
                 aggregatedContent.AppendLine(methodContent);
+                aggregatedContent.AppendLine("}");
                 aggregatedContent.AppendLine();
             }
         }

--- a/StewardEF/VersionChecker.cs
+++ b/StewardEF/VersionChecker.cs
@@ -5,6 +5,8 @@ using Spectre.Console;
 
 internal static class VersionChecker
 {
+    private const string DefaultVersion = "0.0.0";
+
     public static async Task CheckForLatestVersion()
     {
         try
@@ -22,7 +24,7 @@ internal static class VersionChecker
             // fail silently
         }
     }
-    
+
     private static async Task<string> GetLatestReleaseVersion()
     {
         var latestCraftsmanPath = "https://github.com/pdevito3/stewardef/releases/latest";
@@ -33,13 +35,13 @@ internal static class VersionChecker
         response.EnsureSuccessStatusCode();
 
         var redirectUrl = response?.RequestMessage?.RequestUri;
-        var version = redirectUrl?.ToString().Split('/').Last().Replace("v", "");
+        var version = redirectUrl?.ToString().Split('/').Last().Replace("v", "") ?? DefaultVersion;
         return version;
     }
 
     private static string GetInstalledStewardEfVersion()
     {
-        var installedVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        var installedVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? DefaultVersion;
         installedVersion = installedVersion[0..^2]; // equivalent to installedVersion.Substring(0, installedVersion.Length - 2);
 
         return installedVersion;


### PR DESCRIPTION
Hey,
I've noticed that adding a simple scope bracets fix the issue with duplicate variables in the migrations.
With this tool we have removed 735 migrations and cut CI build times by ~7min - Thanks!