### PR TITLE
Fix ExtractMigrationClassName to strip whitespace and invalid chars

### DIFF
--- a/StewardEF/Commands/SquashMigrations.cs
+++ b/StewardEF/Commands/SquashMigrations.cs
@@ -573,11 +573,11 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
     {
         // EF migration format: YYYYMMDDHHMMSS_MigrationName
         // The timestamp is always 14 digits followed by underscore
-        // Migration name can contain underscores (e.g., Add_User_Table)
+        // Migration name can contain underscores (e.g., Add_User_Table) or spaces (e.g., Add User Table)
         var match = Regex.Match(migrationFileName, @"^\d{14}_(.+)$");
         if (match.Success)
         {
-            return match.Groups[1].Value;
+            return Regex.Replace(match.Groups[1].Value, @"[^\w]", "");
         }
 
         // Fallback to old behavior if format doesn't match


### PR DESCRIPTION
Hi, first off great tool! 
Nicely done :)

I ran into an issue with naming of the designer files however. 
We have alot of migrations with spaces in the name and this results in desginer classnames with whitespaces, which wont compile. 

So this pull request is to fix just that. 

The fix is simply to strip away any non word characters. 
`return Regex.Replace(match.Groups[1].Value, @"[^\w]", "");`

I created a simple test and it should work fine after this. 
```
[Theory]
[InlineData("20240615123045_Add New Table", "AddNewTable")]
[InlineData("20240615123045_Add_New_Table", "Add_New_Table")]
[InlineData("20240615123045_Add  New  Table", "AddNewTable")]
[InlineData("20240615123045_Add_1_New  Table", "Add_1_NewTable")]
[InlineData("20240615123045_Add-New-Table", "AddNewTable")]
[InlineData("20240615123045_Add-£New-€Table}", "AddNewTable")]

public void Test_ExtractMigrationClassName(string fileName, string expectedClassName)
{
    var className = ExtractMigrationClassName(fileName);
    Assert.Equal(expectedClassName, className);
}
```
