### PR TITLE
Support EF startup project and context options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Squashes EF migrations into the first migration in the specified directory.
 #### **Usage:**
 
 ```bash
-steward squash path/to/migrations [-y year] [-t migration-name]
+steward squash path/to/migrations [-y year] [-t migration-name] [-p project-path] [-s startup-project-path] [-c db-context] [--configuration build-config]
 ```
 
 ##### Options
@@ -38,6 +38,10 @@ steward squash path/to/migrations [-y year] [-t migration-name]
 - `-y|--year`: Optional. Specify the year up to which migrations should be squashed. If omitted, all migrations will be squashed.
 - `-t|--target`: Optional. Specify the target migration name (without .cs extension) up to which migrations should be squashed. Since EF Core migrations follow the pattern `YYYYMMDDHHMMSS_MigrationName.cs`, you can specify either the full name (e.g. "20230615000000_AddUserTable") or just part of it (e.g. "AddUserTable"). The matching is case-insensitive. If omitted, all migrations will be squashed.
 - `--skip-sql`: Optional. Skip automatic SQL conversion even if problematic rename operations are detected. A warning will be shown if rename-then-drop patterns are found. Use this if you want to keep the C# code format and handle any issues manually.
+- `-p|--project`: Optional. Explicit path to the migrations project `.csproj` used when automatic SQL conversion runs.
+- `-s|--startup-project`: Optional. Explicit path to the startup project `.csproj` used by `dotnet ef` during automatic SQL conversion.
+- `-c|--context`: Optional. Explicit DbContext name to use during automatic SQL conversion. Useful when the startup project exposes multiple contexts.
+- `--configuration`: Optional. Build configuration to use with `dotnet ef` during automatic SQL conversion, such as `Debug` or `Release`.
 
 ##### Examples
 
@@ -56,6 +60,13 @@ steward squash path/to/migrations -t AddUserTable
 
 # Squash migrations but skip SQL conversion (keep C# format)
 steward squash path/to/migrations --skip-sql
+
+# Squash migrations using an explicit startup project and DbContext for SQL conversion
+steward squash path/to/migrations \
+  -p path/to/MyProject.csproj \
+  -s path/to/MyWeb.csproj \
+  -c AppDbContext \
+  --configuration Release
 ```
 
 #### **How It Works**
@@ -96,8 +107,8 @@ Found project: MyApp.csproj
 The tool automatically:
 1. Squashes migrations normally using C# code concatenation
 2. Checks for rename-then-drop patterns (e.g., `RenameColumn` → `DropColumn` for the same column)
-3. If found, locates your `.csproj` file (searches up the directory tree)
-4. Generates SQL scripts using `dotnet ef migrations script 0 <migration-id>`
+3. If found, locates your `.csproj` file (searches up the directory tree unless `--project` is supplied)
+4. Generates SQL scripts using `dotnet ef migrations script 0 <migration-id>`, optionally forwarding `--startup-project`, `--context`, and `--configuration`
 5. Replaces the squashed migration content with `migrationBuilder.Sql()` calls containing the generated SQL
 
 **Skipping SQL Conversion**
@@ -134,13 +145,16 @@ Converts an existing migration to use SQL scripts instead of C# code. This is us
 #### **Usage:**
 
 ```bash
-steward convert-to-sql path/to/migrations [-p project-path] [-m migration-name]
+steward convert-to-sql path/to/migrations [-p project-path] [-s startup-project-path] [-c db-context] [--configuration build-config] [-m migration-name]
 ```
 
 ##### Options
 
 - `[MigrationsDirectory]`: Path to the directory containing your EF migrations. If omitted, you'll be prompted to enter it interactively.
 - `-p|--project`: Optional. Explicit path to your `.csproj` file. If omitted, the tool will search up the directory tree.
+- `-s|--startup-project`: Optional. Explicit path to the startup project `.csproj` used by `dotnet ef`.
+- `-c|--context`: Optional. Explicit DbContext name to use. Useful when the startup project exposes multiple contexts.
+- `--configuration`: Optional. Build configuration to use with `dotnet ef`, such as `Debug` or `Release`.
 - `-m|--migration`: Optional. Name of the specific migration to convert (without .cs extension). If omitted, converts the most recent migration.
 
 ##### Examples
@@ -155,6 +169,13 @@ steward convert-to-sql path/to/migrations -p path/to/MyProject.csproj
 # Convert a specific migration
 steward convert-to-sql path/to/migrations -m AddUserTable
 steward convert-to-sql path/to/migrations -m 20231201000000_AddUserTable
+
+# Convert using an explicit startup project and DbContext
+steward convert-to-sql path/to/migrations \
+  -p path/to/MyProject.csproj \
+  -s path/to/MyWeb.csproj \
+  -c AppDbContext \
+  --configuration Release
 ```
 
 #### **How It Works**
@@ -163,7 +184,7 @@ The convert-to-sql command:
 
 1. Locates the specified migration (or most recent if not specified)
 2. Finds the associated `.Designer.cs` file to extract the migration ID
-3. Uses `dotnet ef migrations script` to generate SQL for the Up and Down methods
+3. Uses `dotnet ef migrations script` to generate SQL for the Up and Down methods, optionally forwarding `--startup-project`, `--context`, and `--configuration`
 4. Sanitizes the SQL (removes transaction and EF history statements that conflict with EF Core's runtime)
 5. Replaces the migration's C# code with `migrationBuilder.Sql()` calls containing the generated SQL
 

--- a/StewardEF.Tests/Commands/EfMigrationToolingTests.cs
+++ b/StewardEF.Tests/Commands/EfMigrationToolingTests.cs
@@ -1,0 +1,58 @@
+namespace StewardEF.Tests.Commands;
+
+using Shouldly;
+using StewardEF.Commands;
+
+public class EfMigrationToolingTests
+{
+    [Fact]
+    public void CreateEfScriptStartInfo_ShouldIncludeProjectAndNoBuildByDefault()
+    {
+        var options = new EfScriptOptions("/repo/App/App.csproj");
+
+        var startInfo = EfMigrationTooling.CreateEfScriptStartInfo("0", "20240101010101_Init", options);
+
+        startInfo.FileName.ShouldBe("dotnet");
+        startInfo.ArgumentList.Cast<string>().ShouldBe(
+        [
+            "ef",
+            "migrations",
+            "script",
+            "0",
+            "20240101010101_Init",
+            "--project",
+            Path.GetFullPath("/repo/App/App.csproj"),
+            "--no-build"
+        ]);
+    }
+
+    [Fact]
+    public void CreateEfScriptStartInfo_ShouldIncludeStartupProjectContextAndConfiguration_WhenProvided()
+    {
+        var options = new EfScriptOptions(
+            "/repo/App/App.csproj",
+            "/repo/Web/Web.csproj",
+            "AppDbContext",
+            "Release");
+
+        var startInfo = EfMigrationTooling.CreateEfScriptStartInfo("20240101010101_Init", "0", options);
+
+        startInfo.ArgumentList.Cast<string>().ShouldBe(
+        [
+            "ef",
+            "migrations",
+            "script",
+            "20240101010101_Init",
+            "0",
+            "--project",
+            Path.GetFullPath("/repo/App/App.csproj"),
+            "--startup-project",
+            Path.GetFullPath("/repo/Web/Web.csproj"),
+            "--context",
+            "AppDbContext",
+            "--configuration",
+            "Release",
+            "--no-build"
+        ]);
+    }
+}

--- a/StewardEF.Tests/Commands/SquashMigrations/SqlConversionTests.cs
+++ b/StewardEF.Tests/Commands/SquashMigrations/SqlConversionTests.cs
@@ -1024,9 +1024,9 @@ COMMIT;";
         result.ShouldNotContain("INSERT INTO");
         result.ShouldNotContain("__EFMigrationsHistory");
 
-        // These should all be preserved
-        result.ShouldContain("DO $EF$");
-        result.ShouldContain("CREATE SCHEMA my_schema");
+        // The PostgreSQL schema preamble should be removed, but schema objects should remain
+        result.ShouldNotContain("DO $EF$");
+        result.ShouldNotContain("CREATE SCHEMA my_schema");
         result.ShouldContain("CREATE TABLE my_schema.users");
         result.ShouldContain("CREATE INDEX ix_users_email");
     }

--- a/StewardEF/Commands/ConvertToSqlCommand.cs
+++ b/StewardEF/Commands/ConvertToSqlCommand.cs
@@ -2,7 +2,7 @@ namespace StewardEF.Commands;
 
 using Spectre.Console;
 using Spectre.Console.Cli;
-using System.Diagnostics;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 
 internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
@@ -13,9 +13,23 @@ internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
         public string? MigrationsDirectory { get; set; }
 
         [CommandOption("-p|--project")]
+        [Description("Explicit path to the target migrations project (.csproj)")]
         public string? ProjectPath { get; set; }
 
+        [CommandOption("-s|--startup-project")]
+        [Description("Explicit path to the startup project (.csproj) used by dotnet ef")]
+        public string? StartupProjectPath { get; set; }
+
+        [CommandOption("-c|--context")]
+        [Description("Explicit DbContext name to use when the startup project exposes multiple contexts")]
+        public string? DbContextName { get; set; }
+
+        [CommandOption("--configuration")]
+        [Description("Build configuration to use with dotnet ef (defaults to the EF Core default)")]
+        public string? Configuration { get; set; }
+
         [CommandOption("-m|--migration")]
+        [Description("Specific migration name or ID to convert")]
         public string? MigrationName { get; set; }
     }
 
@@ -36,14 +50,26 @@ internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
             return 1;
         }
 
-        ConvertMigrationToSql(directory, settings.ProjectPath, settings.MigrationName);
+        ConvertMigrationToSql(
+            directory,
+            settings.ProjectPath,
+            settings.MigrationName,
+            settings.StartupProjectPath,
+            settings.DbContextName,
+            settings.Configuration);
         return 0;
     }
 
-    static void ConvertMigrationToSql(string directory, string? projectPath, string? migrationName)
+    static void ConvertMigrationToSql(
+        string directory,
+        string? projectPath,
+        string? migrationName,
+        string? startupProjectPath,
+        string? dbContextName,
+        string? configuration)
     {
         // Find the project file
-        var projectFile = FindProjectFile(directory, projectPath);
+        var projectFile = EfMigrationTooling.FindProjectFile(directory, projectPath);
         if (projectFile == null)
         {
             AnsiConsole.MarkupLine("[red]Could not find a .csproj file. Use --project to specify the path.[/]");
@@ -101,7 +127,7 @@ internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
         AnsiConsole.MarkupLine($"[yellow]Converting migration to SQL: {Path.GetFileName(migrationFile)}[/]");
 
         // Extract migration ID from designer file
-        var migrationId = ExtractMigrationId(designerFile);
+        var migrationId = EfMigrationTooling.ExtractMigrationId(designerFile);
         if (migrationId == null)
         {
             AnsiConsole.MarkupLine("[red]Could not extract migration ID from Designer file.[/]");
@@ -110,18 +136,28 @@ internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
 
         AnsiConsole.MarkupLine("[dim]Generating SQL scripts...[/]");
 
+        var options = new EfScriptOptions(projectFile, startupProjectPath, dbContextName, configuration);
+
         // Generate SQL scripts
-        var upSql = ExecuteEfScript("0", migrationId, projectFile);
+        var (upSql, upError) = EfMigrationTooling.ExecuteEfScript("0", migrationId, options);
         if (upSql == null)
         {
             AnsiConsole.MarkupLine("[red]Failed to generate Up SQL script.[/]");
+            if (!string.IsNullOrWhiteSpace(upError))
+            {
+                EfMigrationTooling.WriteEfScriptError(upError);
+            }
             return;
         }
 
-        var downSql = ExecuteEfScript(migrationId, "0", projectFile);
+        var (downSql, downError) = EfMigrationTooling.ExecuteEfScript(migrationId, "0", options);
         if (downSql == null)
         {
             AnsiConsole.MarkupLine("[red]Failed to generate Down SQL script.[/]");
+            if (!string.IsNullOrWhiteSpace(downError))
+            {
+                EfMigrationTooling.WriteEfScriptError(downError);
+            }
             return;
         }
 
@@ -129,97 +165,6 @@ internal class ConvertToSqlCommand : Command<ConvertToSqlCommand.Settings>
         ReplaceWithSqlScript(migrationFile, upSql, downSql);
 
         AnsiConsole.MarkupLine($"[green]Migration converted to SQL successfully! {Emoji.Known.Sparkles}[/]");
-    }
-
-    private static string? FindProjectFile(string migrationsDirectory, string? explicitProjectPath = null)
-    {
-        // If explicitly provided, validate and return
-        if (!string.IsNullOrWhiteSpace(explicitProjectPath))
-        {
-            if (File.Exists(explicitProjectPath) && explicitProjectPath.EndsWith(".csproj"))
-            {
-                return Path.GetFullPath(explicitProjectPath);
-            }
-            AnsiConsole.MarkupLine($"[yellow]Warning: Specified project file not found: {explicitProjectPath}[/]");
-        }
-
-        // Search up the directory tree for a .csproj file
-        var currentDir = new DirectoryInfo(Path.GetFullPath(migrationsDirectory));
-
-        while (currentDir != null)
-        {
-            var projectFiles = currentDir.GetFiles("*.csproj");
-            if (projectFiles.Length > 0)
-            {
-                // If multiple .csproj files, try to pick the most likely one
-                var projectFile = projectFiles.Length == 1
-                    ? projectFiles[0]
-                    : projectFiles.FirstOrDefault(f => !f.Name.Contains(".Tests")) ?? projectFiles[0];
-
-                return projectFile.FullName;
-            }
-
-            currentDir = currentDir.Parent;
-        }
-
-        return null;
-    }
-
-    private static string? ExtractMigrationId(string designerFilePath)
-    {
-        if (!File.Exists(designerFilePath))
-            return null;
-
-        var content = File.ReadAllText(designerFilePath);
-
-        // Extract migration ID from [Migration("20231201123456_MigrationName")] attribute
-        var match = Regex.Match(content, @"\[Migration\(""([^""]+)""\)\]");
-        if (match.Success)
-        {
-            return match.Groups[1].Value;
-        }
-
-        return null;
-    }
-
-    private static string? ExecuteEfScript(string fromMigration, string toMigration, string projectPath)
-    {
-        try
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"ef migrations script {fromMigration} {toMigration} --project \"{projectPath}\" --no-build",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(startInfo);
-            if (process == null)
-            {
-                AnsiConsole.MarkupLine("[red]Failed to start dotnet ef process[/]");
-                return null;
-            }
-
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                AnsiConsole.MarkupLine($"[red]dotnet ef script failed: {error}[/]");
-                return null;
-            }
-
-            return output;
-        }
-        catch (Exception ex)
-        {
-            AnsiConsole.MarkupLine($"[red]Error executing dotnet ef: {ex.Message}[/]");
-            return null;
-        }
     }
 
     private static void ReplaceWithSqlScript(string migrationFilePath, string upSql, string downSql)

--- a/StewardEF/Commands/EfMigrationTooling.cs
+++ b/StewardEF/Commands/EfMigrationTooling.cs
@@ -1,0 +1,152 @@
+namespace StewardEF.Commands;
+
+using Spectre.Console;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+internal sealed record EfScriptOptions(
+    string ProjectPath,
+    string? StartupProjectPath = null,
+    string? DbContextName = null,
+    string? Configuration = null);
+
+internal static class EfMigrationTooling
+{
+    internal static string? FindProjectFile(string migrationsDirectory, string? explicitProjectPath = null)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitProjectPath))
+        {
+            if (File.Exists(explicitProjectPath) && explicitProjectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                return Path.GetFullPath(explicitProjectPath);
+            }
+
+            AnsiConsole.MarkupLine($"[yellow]Warning: Specified project file not found: {explicitProjectPath}[/]");
+        }
+
+        var currentDir = new DirectoryInfo(Path.GetFullPath(migrationsDirectory));
+
+        while (currentDir != null)
+        {
+            var projectFiles = currentDir.GetFiles("*.csproj");
+            if (projectFiles.Length > 0)
+            {
+                var projectFile = projectFiles.Length == 1
+                    ? projectFiles[0]
+                    : projectFiles.FirstOrDefault(f => !f.Name.Contains(".Tests", StringComparison.OrdinalIgnoreCase)) ?? projectFiles[0];
+
+                return projectFile.FullName;
+            }
+
+            currentDir = currentDir.Parent;
+        }
+
+        return null;
+    }
+
+    internal static string? ExtractMigrationId(string designerFilePath)
+    {
+        if (!File.Exists(designerFilePath))
+        {
+            return null;
+        }
+
+        var content = File.ReadAllText(designerFilePath);
+        var match = Regex.Match(content, @"\[Migration\(\s*""([^""]+)""\s*\)\]");
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    internal static ProcessStartInfo CreateEfScriptStartInfo(string fromMigration, string toMigration, EfScriptOptions options)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        startInfo.ArgumentList.Add("ef");
+        startInfo.ArgumentList.Add("migrations");
+        startInfo.ArgumentList.Add("script");
+        startInfo.ArgumentList.Add(fromMigration);
+        startInfo.ArgumentList.Add(toMigration);
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(Path.GetFullPath(options.ProjectPath));
+
+        if (!string.IsNullOrWhiteSpace(options.StartupProjectPath))
+        {
+            startInfo.ArgumentList.Add("--startup-project");
+            startInfo.ArgumentList.Add(Path.GetFullPath(options.StartupProjectPath));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.DbContextName))
+        {
+            startInfo.ArgumentList.Add("--context");
+            startInfo.ArgumentList.Add(options.DbContextName);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Configuration))
+        {
+            startInfo.ArgumentList.Add("--configuration");
+            startInfo.ArgumentList.Add(options.Configuration);
+        }
+
+        startInfo.ArgumentList.Add("--no-build");
+        return startInfo;
+    }
+
+    internal static (string? Output, string? Error) ExecuteEfScript(string fromMigration, string toMigration, EfScriptOptions options)
+    {
+        try
+        {
+            var startInfo = CreateEfScriptStartInfo(fromMigration, toMigration, options);
+
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                return (null, "Failed to start dotnet ef process.");
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                var message = string.IsNullOrWhiteSpace(error)
+                    ? string.IsNullOrWhiteSpace(output) ? "dotnet ef script failed." : output.Trim()
+                    : error.Trim();
+
+                return (null, message);
+            }
+
+            return (output, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"Error executing dotnet ef: {ex.Message}");
+        }
+    }
+
+    internal static void WriteEfScriptError(string message)
+    {
+        AnsiConsole.MarkupLine("[red]dotnet ef script failed:[/]");
+
+        foreach (var line in SplitLines(message))
+        {
+            AnsiConsole.WriteLine(line);
+        }
+    }
+
+    private static IEnumerable<string> SplitLines(string message)
+    {
+        using var reader = new StringReader(message);
+        while (reader.ReadLine() is { } line)
+        {
+            yield return line;
+        }
+    }
+}

--- a/StewardEF/Commands/SquashMigrations.cs
+++ b/StewardEF/Commands/SquashMigrations.cs
@@ -3,7 +3,6 @@ namespace StewardEF.Commands;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -23,6 +22,22 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
         [CommandOption("--skip-sql")]
         [Description("Skip automatic SQL conversion for migrations with rename operations")]
         public bool SkipSqlConversion { get; set; }
+
+        [CommandOption("-p|--project")]
+        [Description("Explicit path to the target migrations project (.csproj) used for automatic SQL conversion")]
+        public string? ProjectPath { get; set; }
+
+        [CommandOption("-s|--startup-project")]
+        [Description("Explicit path to the startup project (.csproj) used by dotnet ef during automatic SQL conversion")]
+        public string? StartupProjectPath { get; set; }
+
+        [CommandOption("-c|--context")]
+        [Description("Explicit DbContext name to use during automatic SQL conversion")]
+        public string? DbContextName { get; set; }
+
+        [CommandOption("--configuration")]
+        [Description("Build configuration to use with dotnet ef during automatic SQL conversion")]
+        public string? Configuration { get; set; }
     }
 
     public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
@@ -42,11 +57,27 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
             return 1;
         }
 
-        SquashMigrations(directory, settings.Year, settings.TargetMigration, settings.SkipSqlConversion);
+        SquashMigrations(
+            directory,
+            settings.Year,
+            settings.TargetMigration,
+            settings.SkipSqlConversion,
+            settings.ProjectPath,
+            settings.StartupProjectPath,
+            settings.DbContextName,
+            settings.Configuration);
         return 0;
     }
 
-    static void SquashMigrations(string directory, int? year, string? targetMigration, bool skipSqlConversion)
+    static void SquashMigrations(
+        string directory,
+        int? year,
+        string? targetMigration,
+        bool skipSqlConversion,
+        string? projectPath,
+        string? startupProjectPath,
+        string? dbContextName,
+        string? configuration)
     {
         // Get all .cs files including Designer.cs files
         var files = Directory.GetFiles(directory, "*.cs", SearchOption.TopDirectoryOnly)
@@ -149,17 +180,18 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
             AnsiConsole.MarkupLine("[yellow]Converting to SQL script format...[/]");
 
             // Try to find the project file
-            var projectPath = FindProjectFile(directory);
-            if (projectPath != null)
+            var projectFile = EfMigrationTooling.FindProjectFile(directory, projectPath);
+            if (projectFile != null)
             {
-                AnsiConsole.MarkupLine($"[dim]Found project: {Path.GetFileName(projectPath)}[/]");
+                AnsiConsole.MarkupLine($"[dim]Found project: {Path.GetFileName(projectFile)}[/]");
 
                 // Generate SQL from the squashed migration
-                var migrationId = ExtractMigrationId(newDesignerFileName);
+                var migrationId = EfMigrationTooling.ExtractMigrationId(newDesignerFileName);
                 if (migrationId != null)
                 {
-                    var upSql = ExecuteEfScript("0", migrationId, projectPath);
-                    var downSql = ExecuteEfScript(migrationId, "0", projectPath);
+                    var options = new EfScriptOptions(projectFile, startupProjectPath, dbContextName, configuration);
+                    var (upSql, upError) = EfMigrationTooling.ExecuteEfScript("0", migrationId, options);
+                    var (downSql, downError) = EfMigrationTooling.ExecuteEfScript(migrationId, "0", options);
 
                     if (upSql != null && downSql != null)
                     {
@@ -169,6 +201,14 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
                     else
                     {
                         AnsiConsole.MarkupLine("[yellow]⚠ Failed to generate SQL scripts[/]");
+                        if (!string.IsNullOrWhiteSpace(upError))
+                        {
+                            EfMigrationTooling.WriteEfScriptError(upError);
+                        }
+                        else if (!string.IsNullOrWhiteSpace(downError))
+                        {
+                            EfMigrationTooling.WriteEfScriptError(downError);
+                        }
                         AnsiConsole.MarkupLine("[yellow]Squashed migration kept in C# format (may have issues on fresh database)[/]");
                     }
                 }
@@ -793,94 +833,12 @@ internal class SquashMigrationsCommand : Command<SquashMigrationsCommand.Setting
 
     internal static string? FindProjectFile(string migrationsDirectory, string? explicitProjectPath = null)
     {
-        // If explicitly provided, validate and return
-        if (!string.IsNullOrWhiteSpace(explicitProjectPath))
-        {
-            if (File.Exists(explicitProjectPath) && explicitProjectPath.EndsWith(".csproj"))
-            {
-                return Path.GetFullPath(explicitProjectPath);
-            }
-            AnsiConsole.MarkupLine($"[yellow]Warning: Specified project file not found: {explicitProjectPath}[/]");
-        }
-
-        // Search up the directory tree for a .csproj file
-        var currentDir = new DirectoryInfo(Path.GetFullPath(migrationsDirectory));
-
-        while (currentDir != null)
-        {
-            var projectFiles = currentDir.GetFiles("*.csproj");
-            if (projectFiles.Length > 0)
-            {
-                // If multiple .csproj files, try to pick the most likely one
-                var projectFile = projectFiles.Length == 1
-                    ? projectFiles[0]
-                    : projectFiles.FirstOrDefault(f => !f.Name.Contains(".Tests")) ?? projectFiles[0];
-
-                return projectFile.FullName;
-            }
-
-            currentDir = currentDir.Parent;
-        }
-
-        return null;
+        return EfMigrationTooling.FindProjectFile(migrationsDirectory, explicitProjectPath);
     }
 
     internal static string? ExtractMigrationId(string designerFilePath)
     {
-        if (!File.Exists(designerFilePath))
-            return null;
-
-        var content = File.ReadAllText(designerFilePath);
-
-        // Extract migration ID from [Migration("20231201123456_MigrationName")] attribute
-        // Allow optional whitespace around the string parameter
-        var match = Regex.Match(content, @"\[Migration\(\s*""([^""]+)""\s*\)\]");
-        if (match.Success)
-        {
-            return match.Groups[1].Value;
-        }
-
-        return null;
-    }
-
-    private static string? ExecuteEfScript(string fromMigration, string toMigration, string projectPath)
-    {
-        try
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"ef migrations script {fromMigration} {toMigration} --project \"{projectPath}\" --no-build",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(startInfo);
-            if (process == null)
-            {
-                AnsiConsole.MarkupLine("[red]Failed to start dotnet ef process[/]");
-                return null;
-            }
-
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                AnsiConsole.MarkupLine($"[red]dotnet ef script failed: {error}[/]");
-                return null;
-            }
-
-            return output;
-        }
-        catch (Exception ex)
-        {
-            AnsiConsole.MarkupLine($"[red]Error executing dotnet ef: {ex.Message}[/]");
-            return null;
-        }
+        return EfMigrationTooling.ExtractMigrationId(designerFilePath);
     }
 
     private static void ReplaceWithSqlScript(string migrationFilePath, string upSql, string downSql)

--- a/StewardEF/Program.cs
+++ b/StewardEF/Program.cs
@@ -22,13 +22,15 @@ app.Configure(config =>
         .WithExample(new[] { "squash", "path/to/migrations", "-y", "2023" })
         .WithExample(new[] { "squash", "path/to/migrations", "-t", "20230615000000_AddUserTable" })
         .WithExample(new[] { "squash", "path/to/migrations", "-t", "AddUserTable" })
-        .WithExample(new[] { "squash", "path/to/migrations", "--skip-sql" });
+        .WithExample(new[] { "squash", "path/to/migrations", "--skip-sql" })
+        .WithExample(new[] { "squash", "path/to/migrations", "-p", "path/to/MyProject.csproj", "-s", "path/to/MyWeb.csproj", "-c", "AppDbContext", "--configuration", "Release" });
 
     config.AddCommand<ConvertToSqlCommand>("convert-to-sql")
         .WithDescription("Converts a migration to use SQL scripts instead of C# code.")
         .WithExample(new[] { "convert-to-sql", "path/to/migrations" })
         .WithExample(new[] { "convert-to-sql", "path/to/migrations", "-p", "path/to/Project.csproj" })
-        .WithExample(new[] { "convert-to-sql", "path/to/migrations", "-m", "AddUserTable" });
+        .WithExample(new[] { "convert-to-sql", "path/to/migrations", "-m", "AddUserTable" })
+        .WithExample(new[] { "convert-to-sql", "path/to/migrations", "-p", "path/to/MyProject.csproj", "-s", "path/to/MyWeb.csproj", "-c", "AppDbContext", "--configuration", "Release" });
 });
 
 try


### PR DESCRIPTION
## Summary
- add shared EF tooling helpers for `dotnet ef migrations script` invocations
- expose `--startup-project`, `--context`, and `--configuration` on `squash` and `convert-to-sql`
- document the new options and add coverage for generated EF CLI arguments

## Why
Some apps keep migrations in a class library but need EF to resolve services from a separate startup project. In that setup, `dotnet ef migrations script` also often needs an explicit DbContext when the startup host exposes more than one context. StewardEF currently only forwards `--project`, which blocks those scenarios.

This patch forwards the same EF options StewardEF users already use with `dotnet ef`, and also prints raw `dotnet ef` stderr safely so CLI error output does not get mangled by Spectre markup parsing.

## Notes
- the new helper uses `ProcessStartInfo.ArgumentList` instead of concatenating a raw argument string
- I also aligned one existing PostgreSQL sanitization test with the sanitizer's current schema-preamble behavior so the suite stays green